### PR TITLE
fix: fixed additional properties with invalid patterns

### DIFF
--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -37,25 +37,22 @@
         "ports": {
           "description": "List of network ports published by the service.",
           "type": "object",
-          "additionalProperties": true,
           "minProperties": 1,
-          "patternProperties": {
-            "^*": {
-              "description": "The network port description.",
-              "type": "object",
-              "required": [
-                "targetPort"
-              ],
-              "additionalProperties": false,
-              "properties": {
-                "port": {
-                  "description": "The public service port.",
-                  "type": "number"
-                },
-                "targetPort": {
-                  "description": "The internal service port.",
-                  "type": "number"
-                }
+          "additionalProperties": {
+            "description": "The network port description.",
+            "type": "object",
+            "required": [
+              "targetPort"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "port": {
+                "description": "The public service port.",
+                "type": "number"
+              },
+              "targetPort": {
+                "description": "The internal service port.",
+                "type": "number"
               }
             }
           }
@@ -65,147 +62,144 @@
     "containers": {
       "description": "The declared Score Specification version.",
       "type": "object",
-      "additionalProperties": true,
       "minProperties": 1,
-      "patternProperties": {
-        "^*": {
-          "description": "The container name.",
-          "type": "object",
-          "required": [
-            "image"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "image": {
-              "description": "The image name and tag.",
+      "additionalProperties": {
+        "description": "The container name.",
+        "type": "object",
+        "required": [
+          "image"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "image": {
+            "description": "The image name and tag.",
+            "type": "string"
+          },
+          "command": {
+            "description": "If specified, overrides container entry point.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
               "type": "string"
-            },
-            "command": {
-              "description": "If specified, overrides container entry point.",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "string"
-              }
-            },
-            "args": {
-              "description": "If specified, overrides container entry point arguments.",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "string"
-              }
-            },
-            "variables": {
-              "description": "The environment variables for the container.",
-              "type": "object",
-              "minProperties": 1,
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "files": {
-              "description": "The extra files to mount.",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "object",
-                "required": [
-                  "target"
-                ],
-                "properties": {
-                  "target": {
-                    "description": "The file path and name.",
-                    "type": "string"
-                  },
-                  "mode": {
-                    "description": "The file access mode.",
-                    "type": "string"
-                  },
-                  "source": {
-                    "description": "The relative or absolute path to the content file.",
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "content": {
-                    "description": "The inline content for the file.",
-                    "anyOf": [{
-                        "type": "string"
-                      }, {
-                        "deprecated": true,
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                          "type": "string"
-                        }
-                      }]
-                  },
-                  "noExpand": {
-                    "description": "If set to true, the placeholders expansion will not occur in the contents of the file.",
-                    "type": "boolean"
-                  }
-                },
-                "oneOf": [{ 
-                    "required": ["content"]
-                  }, { 
-                    "required": ["source"]
-                  }]
-              }
-            },
-            "volumes": {
-              "description": "The volumes to mount.",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "object",
-                "required": [
-                  "source",
-                  "target"
-                ],
-                "properties": {
-                  "source": {
-                    "description": "The external volume reference.",
-                    "type": "string"
-                  },
-                  "path": {
-                    "description": "An optional sub path in the volume.",
-                    "type": "string"
-                  },
-                  "target": {
-                    "description": "The target mount on the container.",
-                    "type": "string"
-                  },
-                  "read_only": {
-                    "description": "Indicates if the volume should be mounted in a read-only mode.",
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "resources": {
-              "description": "The compute resources for the container.",
-              "type": "object",
-              "minProperties": 1,
-              "additionalProperties": false,
-              "properties": {
-                "limits": {
-                  "description": "The maximum allowed resources for the container.",
-                  "$ref": "#/properties/containers/definitions/resourcesLimits"
-                },
-                "requests": {
-                  "description": "The minimal resources required for the container.",
-                  "$ref": "#/properties/containers/definitions/resourcesLimits"
-                }
-              }
-            },
-            "livenessProbe": {
-              "description": "The liveness probe for the container.",
-              "$ref": "#/properties/containers/definitions/containerProbe"
-            },
-            "readinessProbe": {
-              "description": "The readiness probe for the container.",
-              "$ref": "#/properties/containers/definitions/containerProbe"
             }
+          },
+          "args": {
+            "description": "If specified, overrides container entry point arguments.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          },
+          "variables": {
+            "description": "The environment variables for the container.",
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "files": {
+            "description": "The extra files to mount.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "target"
+              ],
+              "properties": {
+                "target": {
+                  "description": "The file path and name.",
+                  "type": "string"
+                },
+                "mode": {
+                  "description": "The file access mode.",
+                  "type": "string"
+                },
+                "source": {
+                  "description": "The relative or absolute path to the content file.",
+                  "type": "string",
+                  "minLength": 1
+                },
+                "content": {
+                  "description": "The inline content for the file.",
+                  "anyOf": [{
+                      "type": "string"
+                    }, {
+                      "deprecated": true,
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {
+                        "type": "string"
+                      }
+                    }]
+                },
+                "noExpand": {
+                  "description": "If set to true, the placeholders expansion will not occur in the contents of the file.",
+                  "type": "boolean"
+                }
+              },
+              "oneOf": [{ 
+                  "required": ["content"]
+                }, { 
+                  "required": ["source"]
+                }]
+            }
+          },
+          "volumes": {
+            "description": "The volumes to mount.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "source",
+                "target"
+              ],
+              "properties": {
+                "source": {
+                  "description": "The external volume reference.",
+                  "type": "string"
+                },
+                "path": {
+                  "description": "An optional sub path in the volume.",
+                  "type": "string"
+                },
+                "target": {
+                  "description": "The target mount on the container.",
+                  "type": "string"
+                },
+                "read_only": {
+                  "description": "Indicates if the volume should be mounted in a read-only mode.",
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "resources": {
+            "description": "The compute resources for the container.",
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "properties": {
+              "limits": {
+                "description": "The maximum allowed resources for the container.",
+                "$ref": "#/properties/containers/definitions/resourcesLimits"
+              },
+              "requests": {
+                "description": "The minimal resources required for the container.",
+                "$ref": "#/properties/containers/definitions/resourcesLimits"
+              }
+            }
+          },
+          "livenessProbe": {
+            "description": "The liveness probe for the container.",
+            "$ref": "#/properties/containers/definitions/containerProbe"
+          },
+          "readinessProbe": {
+            "description": "The readiness probe for the container.",
+            "$ref": "#/properties/containers/definitions/containerProbe"
           }
         }
       },
@@ -291,52 +285,49 @@
       "description": "The dependencies needed by the Workload.",
       "type": "object",
       "minProperties": 1,
-      "additionalProperties": true,
-      "patternProperties": {
-        "^*": {
-          "description": "The resource name.",
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "description": "The resource in the target environment.",
-              "type": "string"
-            },
-            "class": {
-              "description": "A specialisation of the resource type.",
-              "type": "string",
-              "pattern": "^[a-z0-9](?:-?[a-z0-9]+)+$"
-            },
-            "metadata": {
-              "description": "The metadata for the resource.",
-              "type": "object",
-              "minProperties": 1,
-              "additionalProperties": true,
-              "properties": {
-                "annotations": {
-                  "description": "Annotations that apply to the property.",
-                  "type": "object",
-                  "minProperties": 1,
-                  "additionalProperties": {
-                    "type": "string"
-                  }
+      "additionalProperties": {
+        "description": "The resource name.",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "description": "The resource in the target environment.",
+            "type": "string"
+          },
+          "class": {
+            "description": "A specialisation of the resource type.",
+            "type": "string",
+            "pattern": "^[a-z0-9](?:-?[a-z0-9]+)+$"
+          },
+          "metadata": {
+            "description": "The metadata for the resource.",
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": true,
+            "properties": {
+              "annotations": {
+                "description": "Annotations that apply to the property.",
+                "type": "object",
+                "minProperties": 1,
+                "additionalProperties": {
+                  "type": "string"
                 }
               }
-            },
-            "properties": {
-              "description": "DEPRECATED: The properties that can be referenced in other places in the Score Specification file.",
-              "type": [
-                "object",
-                "null"
-              ]
-            },
-            "params": {
-              "description": "The parameters used to validate or provision the resource in the environment.",
-              "type": "object"
             }
+          },
+          "properties": {
+            "description": "DEPRECATED: The properties that can be referenced in other places in the Score Specification file.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "params": {
+            "description": "The parameters used to validate or provision the resource in the environment.",
+            "type": "object"
           }
         }
       }


### PR DESCRIPTION
I'd like to suggest the following changes to the score schema to make it easier to generate code and validators from the json schema: changing from patternProperties: ^* to an additionalProperties structure.

This should be effectively a no-op change, since the pattern properties were used with no other alternatives.

From the jsonschema docs:

![image](https://github.com/score-spec/schema/assets/1651305/51017ddd-8989-4dd4-9f83-3aed0f7ddfd6)

`^*` is not a valid regex which caused some validators to break, and many code generators to fail to generate map[string]interface{} rather than actually typed maps.

I've tested the new schema by generating code using go-jsonschema:

```
cat score-v1b1.json | jq '. * {"$defs": .properties.containers.definitions} | del(.properties.containers.definitions)' | sed 's,/properties/containers/definitions,/$defs,g' > score-v1b1.json.amended
go run github.com/atombender/go-jsonschema@v0.14.1 -v --schema-output=https://score.dev/schemas/score=types.gen.go --schema-package=https://score.dev/schemas/score=generatedtypes score-v1b1.json.amended
```

I've checked the schema with https://www.jsonschemavalidator.net/ as well.

And I've checked the schema against some sample score files.