### PR TITLE
fix: moved references to global $defs section

### DIFF
--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -124,27 +124,37 @@
                 },
                 "content": {
                   "description": "The inline content for the file.",
-                  "anyOf": [{
+                  "anyOf": [
+                    {
                       "type": "string"
-                    }, {
+                    },
+                    {
                       "deprecated": true,
                       "type": "array",
                       "minItems": 1,
                       "items": {
                         "type": "string"
                       }
-                    }]
+                    }
+                  ]
                 },
                 "noExpand": {
                   "description": "If set to true, the placeholders expansion will not occur in the contents of the file.",
                   "type": "boolean"
                 }
               },
-              "oneOf": [{ 
-                  "required": ["content"]
-                }, { 
-                  "required": ["source"]
-                }]
+              "oneOf": [
+                {
+                  "required": [
+                    "content"
+                  ]
+                },
+                {
+                  "required": [
+                    "source"
+                  ]
+                }
+              ]
             }
           },
           "volumes": {
@@ -185,98 +195,21 @@
             "properties": {
               "limits": {
                 "description": "The maximum allowed resources for the container.",
-                "$ref": "#/properties/containers/definitions/resourcesLimits"
+                "$ref": "#/$defs/resourcesLimits"
               },
               "requests": {
                 "description": "The minimal resources required for the container.",
-                "$ref": "#/properties/containers/definitions/resourcesLimits"
+                "$ref": "#/$defs/resourcesLimits"
               }
             }
           },
           "livenessProbe": {
             "description": "The liveness probe for the container.",
-            "$ref": "#/properties/containers/definitions/containerProbe"
+            "$ref": "#/$defs/containerProbe"
           },
           "readinessProbe": {
             "description": "The readiness probe for the container.",
-            "$ref": "#/properties/containers/definitions/containerProbe"
-          }
-        }
-      },
-      "definitions": {
-        "resourcesLimits": {
-          "description": "The compute resources limits.",
-          "type": "object",
-          "minProperties": 1,
-          "additionalProperties": false,
-          "properties": {
-            "memory": {
-              "description": "The memory limit.",
-              "type": "string"
-            },
-            "cpu": {
-              "description": "The CPU limit.",
-              "type": "string"
-            }
-          }
-        },
-        "containerProbe": {
-          "type": "object",
-          "minProperties": 1,
-          "additionalProperties": false,
-          "properties": {
-            "httpGet": {
-              "$ref": "#/properties/containers/definitions/httpProbe"
-            }
-          }
-        },
-        "httpProbe": {
-          "description": "An HTTP probe details.",
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "path"
-          ],
-          "properties": {
-            "host": {
-              "description": "Host name to connect to. Defaults to the container IP.",
-              "type": "string"
-            },
-            "scheme": {
-              "description": "Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.",
-              "type": "string",
-              "enum": [
-                "HTTP",
-                "HTTPS"
-              ]
-            },
-            "path": {
-              "description": "The path of the HTTP probe endpoint.",
-              "type": "string"
-            },
-            "port": {
-              "description": "The path of the HTTP probe endpoint.",
-              "type": "number"
-            },
-            "httpHeaders": {
-              "description": "Additional HTTP headers to send with the request",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "description": "The HTTP header name.",
-                    "type": "string"
-                  },
-                  "value": {
-                    "description": "The HTTP header value.",
-                    "type": "string"
-                  }
-                }
-              }
-            }
+            "$ref": "#/$defs/containerProbe"
           }
         }
       }
@@ -328,6 +261,83 @@
           "params": {
             "description": "The parameters used to validate or provision the resource in the environment.",
             "type": "object"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "resourcesLimits": {
+      "description": "The compute resources limits.",
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "memory": {
+          "description": "The memory limit.",
+          "type": "string"
+        },
+        "cpu": {
+          "description": "The CPU limit.",
+          "type": "string"
+        }
+      }
+    },
+    "containerProbe": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "httpGet": {
+          "$ref": "#/$defs/httpProbe"
+        }
+      }
+    },
+    "httpProbe": {
+      "description": "An HTTP probe details.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "host": {
+          "description": "Host name to connect to. Defaults to the container IP.",
+          "type": "string"
+        },
+        "scheme": {
+          "description": "Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.",
+          "type": "string",
+          "enum": [
+            "HTTP",
+            "HTTPS"
+          ]
+        },
+        "path": {
+          "description": "The path of the HTTP probe endpoint.",
+          "type": "string"
+        },
+        "port": {
+          "description": "The path of the HTTP probe endpoint.",
+          "type": "number"
+        },
+        "httpHeaders": {
+          "description": "Additional HTTP headers to send with the request",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "description": "The HTTP header name.",
+                "type": "string"
+              },
+              "value": {
+                "description": "The HTTP header value.",
+                "type": "string"
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
According to https://json-schema.org/understanding-json-schema/structuring#dollardefs, although refs can point to arbitrary parts of the schema. The `$defs` section is standardized and understood to contain re-usable sub schemas.

The current approach with a `definitions` payload underneath the `properties.containers` section may be rejected by some schema checkers since it's an unknown field in the json schema 2020 spec.

This should have limited effect on anyone generating code from these specs, since the exact path to the referenced object doesn't generally matter, just the final type name.