### PR TITLE
fix: converts anonmyous un-named structs into top-level defs

### DIFF
--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -39,22 +39,7 @@
           "type": "object",
           "minProperties": 1,
           "additionalProperties": {
-            "description": "The network port description.",
-            "type": "object",
-            "required": [
-              "targetPort"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "port": {
-                "description": "The public service port.",
-                "type": "number"
-              },
-              "targetPort": {
-                "description": "The internal service port.",
-                "type": "number"
-              }
-            }
+            "$ref": "#/$defs/servicePort"
           }
         }
       }
@@ -64,154 +49,7 @@
       "type": "object",
       "minProperties": 1,
       "additionalProperties": {
-        "description": "The container name.",
-        "type": "object",
-        "required": [
-          "image"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "image": {
-            "description": "The image name and tag.",
-            "type": "string"
-          },
-          "command": {
-            "description": "If specified, overrides container entry point.",
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "type": "string"
-            }
-          },
-          "args": {
-            "description": "If specified, overrides container entry point arguments.",
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "type": "string"
-            }
-          },
-          "variables": {
-            "description": "The environment variables for the container.",
-            "type": "object",
-            "minProperties": 1,
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "files": {
-            "description": "The extra files to mount.",
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "type": "object",
-              "required": [
-                "target"
-              ],
-              "properties": {
-                "target": {
-                  "description": "The file path and name.",
-                  "type": "string"
-                },
-                "mode": {
-                  "description": "The file access mode.",
-                  "type": "string"
-                },
-                "source": {
-                  "description": "The relative or absolute path to the content file.",
-                  "type": "string",
-                  "minLength": 1
-                },
-                "content": {
-                  "description": "The inline content for the file.",
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "deprecated": true,
-                      "type": "array",
-                      "minItems": 1,
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  ]
-                },
-                "noExpand": {
-                  "description": "If set to true, the placeholders expansion will not occur in the contents of the file.",
-                  "type": "boolean"
-                }
-              },
-              "oneOf": [
-                {
-                  "required": [
-                    "content"
-                  ]
-                },
-                {
-                  "required": [
-                    "source"
-                  ]
-                }
-              ]
-            }
-          },
-          "volumes": {
-            "description": "The volumes to mount.",
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "type": "object",
-              "required": [
-                "source",
-                "target"
-              ],
-              "properties": {
-                "source": {
-                  "description": "The external volume reference.",
-                  "type": "string"
-                },
-                "path": {
-                  "description": "An optional sub path in the volume.",
-                  "type": "string"
-                },
-                "target": {
-                  "description": "The target mount on the container.",
-                  "type": "string"
-                },
-                "read_only": {
-                  "description": "Indicates if the volume should be mounted in a read-only mode.",
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "resources": {
-            "description": "The compute resources for the container.",
-            "type": "object",
-            "minProperties": 1,
-            "additionalProperties": false,
-            "properties": {
-              "limits": {
-                "description": "The maximum allowed resources for the container.",
-                "$ref": "#/$defs/resourcesLimits"
-              },
-              "requests": {
-                "description": "The minimal resources required for the container.",
-                "$ref": "#/$defs/resourcesLimits"
-              }
-            }
-          },
-          "livenessProbe": {
-            "description": "The liveness probe for the container.",
-            "$ref": "#/$defs/containerProbe"
-          },
-          "readinessProbe": {
-            "description": "The readiness probe for the container.",
-            "$ref": "#/$defs/containerProbe"
-          }
-        }
+        "$ref": "#/$defs/container"
       }
     },
     "resources": {
@@ -219,54 +57,75 @@
       "type": "object",
       "minProperties": 1,
       "additionalProperties": {
-        "description": "The resource name.",
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "description": "The resource in the target environment.",
-            "type": "string"
-          },
-          "class": {
-            "description": "A specialisation of the resource type.",
-            "type": "string",
-            "pattern": "^[a-z0-9](?:-?[a-z0-9]+)+$"
-          },
-          "metadata": {
-            "description": "The metadata for the resource.",
-            "type": "object",
-            "minProperties": 1,
-            "additionalProperties": true,
-            "properties": {
-              "annotations": {
-                "description": "Annotations that apply to the property.",
-                "type": "object",
-                "minProperties": 1,
-                "additionalProperties": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "properties": {
-            "description": "DEPRECATED: The properties that can be referenced in other places in the Score Specification file.",
-            "type": [
-              "object",
-              "null"
-            ]
-          },
-          "params": {
-            "description": "The parameters used to validate or provision the resource in the environment.",
-            "type": "object"
-          }
-        }
+        "$ref": "#/$defs/resource"
       }
     }
   },
   "$defs": {
+    "servicePort": {
+      "description": "The network port description.",
+      "type": "object",
+      "required": [
+        "targetPort"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "port": {
+          "description": "The public service port.",
+          "type": "integer"
+        },
+        "targetPort": {
+          "description": "The internal service port.",
+          "type": "integer"
+        }
+      }
+    },
+    "resource": {
+      "description": "The resource name.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "description": "The resource in the target environment.",
+          "type": "string"
+        },
+        "class": {
+          "description": "A specialisation of the resource type.",
+          "type": "string",
+          "pattern": "^[a-z0-9](?:-?[a-z0-9]+)+$"
+        },
+        "metadata": {
+          "description": "The metadata for the resource.",
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": true,
+          "properties": {
+            "annotations": {
+              "description": "Annotations that apply to the property.",
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "properties": {
+          "description": "DEPRECATED: The properties that can be referenced in other places in the Score Specification file.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "params": {
+          "description": "The parameters used to validate or provision the resource in the environment.",
+          "type": "object"
+        }
+      }
+    },
     "resourcesLimits": {
       "description": "The compute resources limits.",
       "type": "object",
@@ -280,6 +139,156 @@
         "cpu": {
           "description": "The CPU limit.",
           "type": "string"
+        }
+      }
+    },
+    "container": {
+      "description": "The container name.",
+      "type": "object",
+      "required": [
+        "image"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "description": "The image name and tag.",
+          "type": "string"
+        },
+        "command": {
+          "description": "If specified, overrides container entry point.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "args": {
+          "description": "If specified, overrides container entry point arguments.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "variables": {
+          "description": "The environment variables for the container.",
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "files": {
+          "description": "The extra files to mount.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "target"
+            ],
+            "properties": {
+              "target": {
+                "description": "The file path and name.",
+                "type": "string"
+              },
+              "mode": {
+                "description": "The file access mode.",
+                "type": "string"
+              },
+              "source": {
+                "description": "The relative or absolute path to the content file.",
+                "type": "string",
+                "minLength": 1
+              },
+              "content": {
+                "description": "The inline content for the file.",
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "deprecated": true,
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              "noExpand": {
+                "description": "If set to true, the placeholders expansion will not occur in the contents of the file.",
+                "type": "boolean"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "content"
+                ]
+              },
+              {
+                "required": [
+                  "source"
+                ]
+              }
+            ]
+          }
+        },
+        "volumes": {
+          "description": "The volumes to mount.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "source",
+              "target"
+            ],
+            "properties": {
+              "source": {
+                "description": "The external volume reference.",
+                "type": "string"
+              },
+              "path": {
+                "description": "An optional sub path in the volume.",
+                "type": "string"
+              },
+              "target": {
+                "description": "The target mount on the container.",
+                "type": "string"
+              },
+              "read_only": {
+                "description": "Indicates if the volume should be mounted in a read-only mode.",
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "resources": {
+          "description": "The compute resources for the container.",
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "description": "The maximum allowed resources for the container.",
+              "$ref": "#/$defs/resourcesLimits"
+            },
+            "requests": {
+              "description": "The minimal resources required for the container.",
+              "$ref": "#/$defs/resourcesLimits"
+            }
+          }
+        },
+        "livenessProbe": {
+          "description": "The liveness probe for the container.",
+          "$ref": "#/$defs/containerProbe"
+        },
+        "readinessProbe": {
+          "description": "The readiness probe for the container.",
+          "$ref": "#/$defs/containerProbe"
         }
       }
     },
@@ -319,7 +328,7 @@
         },
         "port": {
           "description": "The path of the HTTP probe endpoint.",
-          "type": "number"
+          "type": "integer"
         },
         "httpHeaders": {
           "description": "Additional HTTP headers to send with the request",


### PR DESCRIPTION
The current score spec doesn't generate useful code in Go due to its use of un-named objects in maps. This affects the named `containers`, `resources`, and `service.ports` paths in the schema.

This produced problematic structs in Go like the following which is clumsy to use due to the anonymous struct that can't easily be used outside of the map (For example passing as a function parameter or return).

```
// The declared Score Specification version.
type WorkloadSpecContainers map[string]struct {
	// If specified, overrides container entry point arguments.
	Args []string `json:"args,omitempty" yaml:"args,omitempty" mapstructure:"args,omitempty"`

	// If specified, overrides container entry point.
	Command []string `json:"command,omitempty" yaml:"command,omitempty" mapstructure:"command,omitempty"`
```

This PR updates the score spec by converting the remaining anonymous and un-named objects (`additionalProperties: {"type": "object", ...}`) into new top level definitions.

This now generates more useful maps like this which allows `Container` to be used individually. In other languages this renames "fluffy" or "..Property" aliases into more reasonably named objects too.

```
// The declared Score Specification version.
type WorkloadSpecContainers map[string]Container
```

This PR, like the previous two, helps us to start generating named structures from the schema for use in score-go and for use in any other generated libraries.

