### PR TITLE
fix: added missing protocol field in service ports

### DIFF
--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -74,6 +74,10 @@
           "description": "The public service port.",
           "type": "integer"
         },
+        "protocol": {
+          "description": "The transport level protocol. Defaults to TCP.",
+          "type": "string"
+        },
         "targetPort": {
           "description": "The internal service port.",
           "type": "integer"


### PR DESCRIPTION
See #7 for a description of the problem. The `protocol` field is documented but not present in the spec. This is a valid field used already by score-humanitec.

