### PR TITLE
fix: removed fully deprecated and unsupported resource properties field

### DIFF
--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -117,13 +117,6 @@
             }
           }
         },
-        "properties": {
-          "description": "DEPRECATED: The properties that can be referenced in other places in the Score Specification file.",
-          "type": [
-            "object",
-            "null"
-          ]
-        },
         "params": {
           "description": "The parameters used to validate or provision the resource in the environment.",
           "type": "object"


### PR DESCRIPTION
This PR removes a fully deprecated field from the score spec. This field is not described in the docs, and not used in any of the existing score client implementations that we know about. (score-humanitec, score-compose, score-helm, etc). Some clients will silently accept and ignore it.

Since we still have a beta spec, I believe it is better for us to reduce confusion in the spec and push feature deprecation down to the individual implementations at this time.
