### PR TITLE
fix: make httpGet probe port required, fix volume read_only to be camelCase

### DIFF
--- a/samples/score-full.yaml
+++ b/samples/score-full.yaml
@@ -36,11 +36,12 @@ containers:
     - source: volume-name
       target: /mnt/something
       path: /sub/path
-      read_only: false
+      readOnly: false
     - source: volume-two
       target: /mnt/something-else
     livenessProbe:
       httpGet:
+        port: 8080
         path: /livez
     readinessProbe:
       httpGet:

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -205,7 +205,8 @@
           "description": "The environment variables for the container.",
           "type": "object",
           "propertyNames": {
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "^[^=]+$"
           },
           "additionalProperties": {
             "type": "string"
@@ -219,6 +220,7 @@
             "required": [
               "target"
             ],
+            "additionalProperties": false,
             "properties": {
               "target": {
                 "description": "The file path to expose in the container.",
@@ -265,6 +267,7 @@
           "type": "array",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "required": [
               "source",
               "target"

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -282,7 +282,7 @@
                 "description": "The target mount on the container.",
                 "type": "string"
               },
-              "read_only": {
+              "readOnly": {
                 "description": "Indicates if the volume should be mounted in a read-only mode.",
                 "type": "boolean"
               }
@@ -331,11 +331,12 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "port",
         "path"
       ],
       "properties": {
         "host": {
-          "description": "Host name to connect to. Defaults to the container IP.",
+          "description": "Host name to connect to. Defaults to the workload IP. The is equivalent to a Host HTTP header.",
           "type": "string"
         },
         "scheme": {
@@ -347,11 +348,11 @@
           ]
         },
         "path": {
-          "description": "The path of the HTTP probe endpoint.",
+          "description": "The path to access on the HTTP server.",
           "type": "string"
         },
         "port": {
-          "description": "The path of the HTTP probe endpoint.",
+          "description": "The port to access on the workload.",
           "type": "integer",
           "minimum": 1,
           "maximum": 65535
@@ -365,7 +366,8 @@
             "properties": {
               "name": {
                 "description": "The HTTP header name.",
-                "type": "string"
+                "type": "string",
+                "pattern": "^[A-Za-z0-9_-]+$"
               },
               "value": {
                 "description": "The HTTP header value.",


### PR DESCRIPTION
This PR fixes some trailing issues in the beta spec and improves the validation a bit further.

1. **Breaking Change**, `containers.*.volumes.*.read_only` -> `readOnly` to match all the other fields.
2. **Breaking Change**, `containers.*.(livenessProbe|readinessProbe).httpGet.port` is now required. (You can't really default this).
3. Improve validation on `containers.*.variables` to disallow `=` from environment variable names
4. added `additionalProperties: false` to `containers.*.volumes` and `containers.*.files`
5. Fixed some description fields on probes

I don't expect this to cause issues in practise. I'm not aware of any examples that show the probes without a port. And we can document the fix to the read only property so that customers can fix it easily when the score implementation flags that the `read_only` form is not supported.