### PR TITLE
fix: improved specification of http probe

### DIFF
--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -340,7 +340,8 @@
       "properties": {
         "host": {
           "description": "Host name to connect to. Defaults to the workload IP. The is equivalent to a Host HTTP header.",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "scheme": {
           "description": "Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.",
@@ -366,6 +367,10 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
+            "required": [
+              "name",
+              "value"
+            ],
             "properties": {
               "name": {
                 "description": "The HTTP header name.",
@@ -374,7 +379,8 @@
               },
               "value": {
                 "description": "The HTTP header value.",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               }
             }
           }


### PR DESCRIPTION
Found some gaps in the spec here around the http probe.

The headers must have a name and value, and the value cannot be empty. Because `host` is also technically treated as a header/sni-header, it also cannot have an empty value.

These are good improvements, but low urgency because most score implementations work as expected and either ignore or don't support the empty values.