### PR TITLE
feat: added resources.*.id field for sharing resources between Workloads

### DIFF
--- a/samples/score-full.yaml
+++ b/samples/score-full.yaml
@@ -68,3 +68,6 @@ resources:
         data: here
   resource-two2:
     type: Resource-Two
+  resource-three:
+    type: Type-Three
+    id: shared-type-three

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -125,11 +125,18 @@
           "pattern": "^[A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9]$"
         },
         "class": {
-          "description": "A specialisation of the Resource type.",
+          "description": "An optional specialisation of the Resource type.",
           "type": "string",
           "minLength": 2,
           "maxLength": 63,
           "pattern": "^[A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9]$"
+        },
+        "id": {
+          "description": "An optional external Resource identifier. When two resources share the same type, class, and id, they are considered the same resource when used across related Workloads. The id must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 63,
+          "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
         },
         "metadata": {
           "description": "The metadata for the Resource.",


### PR DESCRIPTION
There is an ongoing initiative to support working with multiple Workloads in the same project. Consider cases, such as a frontend and backend application, or api and asynchronous worker service. In these cases, separate score files may be used, but each Workload may need to reference shared resources such as the same database, event bus, dns hostname, or other point of coordination.

To support this, we need an `id` field that indicates as resource that has a fixed identity (type+class+id) across the whole context involving multiple Score files.

The first implementations that intend to support this will be:

1. score-humanitec, which already supports this in the form of an annotation and has been the proof of concept for this feature.
2. score-compose, which is currently being upgraded to support multiple score files at once.


