### PR TITLE
feat: added specification of workload.metadata.annotations

### DIFF
--- a/samples/score-full.yaml
+++ b/samples/score-full.yaml
@@ -2,6 +2,8 @@ apiVersion: score.dev/v1b1
 metadata:
   name: example-workload-name123
   extra-key: extra-value
+  annotations:
+    prefix.com/Another-Key_Annotation.2: something else
 service:
   ports:
     port-one:

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -30,6 +30,18 @@
           "minLength": 2,
           "maxLength": 63,
           "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+        },
+        "annotations": {
+          "description": "Annotations that apply to the Workload. The annotation can contain A-Z, a-z, 0-9, and '-' and may contain an optional /-separated RFC1123 Host Name prefix.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "minLength": 2,
+            "maxLength": 316,
+            "pattern": "^(([a-z0-9][a-z0-9-]{0,61}[a-z0-9])(\\.[a-z0-9][a-z0-9-]{0,61}[a-z0-9])*/)?[A-Za-z0-9][A-Za-z0-9._-]{0,61}[A-Za-z0-9]$"
+          }
         }
       }
     },


### PR DESCRIPTION
Fixes #16. 

These annotations can be passed down to the runtime as annotations or labels and will be merged with any other annotations the score implementation applies. As with other metadata fields these should be available through the `${metadata.annotations.key}` placeholders in score implementations.

cc @johanneswuerbach 