### PR TITLE
fix: update container name description

### DIFF
--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -65,7 +65,7 @@
       }
     },
     "containers": {
-      "description": "The declared Score Specification version. The container name must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
+      "description": "The set of named containers in the Workload. The container name must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
       "type": "object",
       "minProperties": 1,
       "additionalProperties": {


### PR DESCRIPTION
Backport of https://github.com/score-spec/score-go/pull/41/files